### PR TITLE
Adds command to 'generate' `.js` extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ This creates a skeleton `mycomponent.jsx` file inside your `src/components` dire
 
 By default, the resulting file includes React lifecycle methods, like `componentWillMount`. You can skip these by passing in either `-l` or `--skip-lifecycle` to the command above. To know more run `$ react generate -h`.
 
+#### Component file extension
+
+By default, the resulting file will be of `.jsx` extension. You can specify `.js` by passing in either `-j` or `--js` to the command above.
+
 #### Property Types
 
 Currently supported property types:

--- a/bin/react
+++ b/bin/react
@@ -37,6 +37,7 @@ program
 program
   .command("generate <name> [propName:PropType...]")
   .option("-l, --skip-lifecycle", "Skip lifecycle method generation")
+  .option("-j, --js", "Generate JS file")
   .description("Generate a new react component.")
   .action(function(name, propDefs) {
     var props = [];
@@ -64,13 +65,14 @@ program
       });
     });
     var lifecycle = !this.skipLifecycle;
+    var extension = !this.js ? '.jsx' : '.js';
     fs.readFile(path.join(__dirname, "../templates", "component.ejs"), 'utf8', function (err, data) {
       var component = ejs.render(data, {
         lifecycle: lifecycle,
         name: name,
         props: props
       });
-      fs.writeFile(path.join(process.cwd(), "src/components", name.toLowerCase()+".jsx"), component);
+      fs.writeFile(path.join(process.cwd(), "src/components", name.toLowerCase()+extension), component);
     });
   });
 


### PR DESCRIPTION
This PR adds the option to generate a `.js` extension of your component.

```
react generate Foo -j
// => foo.js

react generate Foo --js
// => foo.js

react generate Foo
// => foo.jsx
```
